### PR TITLE
fix: check if the participant is connected with CallType==='video' before muted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Pexip Video Mute Participant Plugin
 
-For documentation on the plugin, please refer to our docs here https://developer.pex.me/plugins/video-mute-participant
+For documentation on the plugin, please refer to our docs here https://developer.pexip.com/docs/plugins/webapp-2/plugin-gallery/video-mute-participant

--- a/plugins/video-mute-participant/video-mute-participant.plugin.js
+++ b/plugins/video-mute-participant/video-mute-participant.plugin.js
@@ -6,7 +6,7 @@
     participants$.subscribe(participants => {
       let state = {};
       participants.forEach(participant => {
-        if (participant.uuid === window.PEX.selfUUID) {
+        if (participant.uuid === window.PEX.selfUUID && participant.callType == 'video') {
           if (participant.isVideoMuted) {
             window.PEX.dispatchAction({type: '[Conference] Mute Camera'});
           } else {


### PR DESCRIPTION
This modification is needed, because normally the user is connected at the beginning as a 'api' user and later is changes to 'video'.